### PR TITLE
endre kontakt fra usbl

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,8 @@ Later, when all the processes like clarification and board approval has been com
     "kjopere": [
       {
         "id": "01010112345",
-        "navn": "Ole Duck",
+        "fornavn": "Ole",
+        "etternavn": "Duck",
         "epost": "ole@andeby.co",
         "adresse": {
           "gateadresse": "Testvegen 1",
@@ -549,7 +550,8 @@ Later, when all the processes like clarification and board approval has been com
       },
       {
         "id": "01010154321",
-        "navn": "Dole Duck",
+        "fornavn": "Dole",
+        "etternavn": "Duck",
         "epost": "dole@andeby.co",
         "adresse": {
           "gateadresse": "Testvegen 1",

--- a/callbackTypes.ts
+++ b/callbackTypes.ts
@@ -41,7 +41,9 @@ export interface Eierbrok {
 
 export interface Kontakt {
   id: string
-  navn: string
+  fornavn?: string
+  etternavn?: string
+  organisasjonsnavn?: string
   kontaktperson?: string
   adresse: Adresse
   epost: string
@@ -122,7 +124,7 @@ export interface ForhandsutlysingUtlopt extends USBLCallback {
   type: CallbackType.forhandsutlysingutlopt
 }
 
-interface SalgsmeldingStyregodkjenning {
+export interface SalgsmeldingStyregodkjenning {
   pakrevd?: boolean
   initiertDato?: string
   meldefrist?: string
@@ -130,19 +132,20 @@ interface SalgsmeldingStyregodkjenning {
   andreHensyn?: string
 }
 
-interface SalgsmeldingForkjopsrett {
+export interface SalgsmeldingForkjopsrett {
   status: string
   andreHensyn?: string
   kjopere: Kontakt[]
 }
 
-interface SalgsmeldingAvklaring {
+export interface SalgsmeldingAvklaring {
   harForkjopsrett: boolean
   type: string
   utlysingsdato?: string
   utlysingssted?: string
   meldefrist?: string
 }
+
 export interface SalgsmeldingMottatt extends USBLCallback {
   type: CallbackType.salgsmeldingmottatt
   avklaring: SalgsmeldingAvklaring


### PR DESCRIPTION
Kontakt som sendes til og fra USBL i salgsmeldinger bør kanskje skille fornavn og etternavn. Her er det gjort i callback. Men kanskje det bør gjøres i request også?