### PR TITLE
New fields on Forhandsutlysning + styregodkjenning

### DIFF
--- a/callbackTypes.ts
+++ b/callbackTypes.ts
@@ -42,6 +42,7 @@ export interface Klient {
   organisasjonsnavn: string
   organisasjonsnummer: string
   epost?: string
+  nettside?: string
   styreleder?: Styreleder
 }
 
@@ -96,9 +97,11 @@ export interface Boliginformasjon extends Callback {
   type: CallbackType.boliginformasjon
   forkjopsrett: {
     harForkjopsrett: boolean
+    kanForhandsutlyses: boolean
     intern?: boolean
     bestillingsformat?: BestillingsFormat
     mottakerType?: BestillingsmottakerType
+    gebyr?: number
   }
   styregodkjenning: {
     pakrevd: boolean
@@ -107,6 +110,7 @@ export interface Boliginformasjon extends Callback {
   }
   salgsmelding: {
     bestillingsformat: BestillingsFormat
+    gebyr?: number
   }
   restanse: {
     bestillingsformat: BestillingsFormat
@@ -145,12 +149,13 @@ export interface ForhandsutlysingUtlopt extends Callback {
 }
 
 export interface SalgsmeldingStyregodkjenning {
+  handteresAvForretningsforer?: boolean
   initiertDato?: string
   meldefrist?: string
 }
 
 export interface SalgsmeldingStyregodkjenningFullfort extends SalgsmeldingStyregodkjenning {
-  statusStyregodkjenning: 'handteres_eksternt' | 'godkjent_av_styret' | 'godkjent_av_bbl' | 'avvist_av_styret' | 'avvist_av_bbl' | 'frist_utlopt'
+  statusStyregodkjenning?: 'godkjent_av_styret' | 'godkjent_av_bbl' | 'avvist_av_styret' | 'avvist_av_bbl' | 'frist_utlopt'
   andreHensyn?: string
 }
 

--- a/requestTypes.ts
+++ b/requestTypes.ts
@@ -107,6 +107,7 @@ export interface Salgsmelding extends BasicProduct {
   type: RequestType.salgsmelding
   kjopere: Kontakt[]
   selgere: Kontakt[]
+  eiere?: Kontakt[]
   salg: Salg
   bolig: Bolig
 }


### PR DESCRIPTION
Salgsmelding callback:
- Fjernet gyldig verdi "handteres_eksternt" fra statusStyregodkjenning. Denne casen blir nå håndtert i neste punkt
- Nytt felt i Salgsmelding der vi sier om styregodkjenning håndteres av forretningsfører 

Boliginformasjon callback:
- Nytt felt i Boliginformasjon der vi sier om forhåndsutlysning kan utføres

Alle callback:
- Nytt felt "klient.nettside" - Nettsiden til laget (f.eks borettslaget)

Salgsmelding request
- Nytt felt "eiere" - Liste med tinglyste eiere. Fylles ut dersom dette er tilgjengelig.  